### PR TITLE
moved sourcing local .zshrc to start

### DIFF
--- a/conf/.zshrc
+++ b/conf/.zshrc
@@ -1,4 +1,11 @@
 ####################################################
+# MACHINE SPECIFIC
+
+if [ -f ~/.zshrc.local ]; then
+  source ~/.zshrc.local
+fi
+
+####################################################
 # ANTIGEN
 
 source ~/.antigen/antigen.zsh
@@ -62,9 +69,3 @@ alias googlebot='curl -L -A "Googlebot/2.1 (+http://www.google.com/bot.html)"'
 # I like things simple :)
 alias tree='tree --charset=ASCII'
 
-####################################################
-# MACHINE SPECIFIC
-
-if [ -f ~/.zshrc.local ]; then
-  source ~/.zshrc.local
-fi


### PR DESCRIPTION
Moved sourcing the .zshrc.local to the beginning so that things like proxies can be set in .zshrc.local to be used for loading the antigen plugins in the main .zshrc